### PR TITLE
updating ancient Python print syntax

### DIFF
--- a/uuv_manipulators_control/src/uuv_manipulators_control/cartesian_controller.py
+++ b/uuv_manipulators_control/src/uuv_manipulators_control/cartesian_controller.py
@@ -139,7 +139,7 @@ class CartesianController(object):
         if self._arm_interface.inverse_kinematics(g_pos, g_quat) is not None:
             return next_goal
         else:
-            print 'Next goal could not be resolved by the inv. kinematics solver.'
+            print('Next goal could not be resolved by the inv. kinematics solver.')
             return self._last_goal
 
     def _home_button_pressed(self, msg):

--- a/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/arm.py
+++ b/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/arm.py
@@ -232,7 +232,7 @@ class ArmInterface(KinChainInterface):
 
     def add_callback(self, topic_name, function_handle):
         if topic_name not in self._subTopics:
-            print 'ArmInterface - Invalid topic name'
+            print('ArmInterface - Invalid topic name')
             return
 
         if topic_name not in self._callbacks:

--- a/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/kin_chain.py
+++ b/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/kin_chain.py
@@ -230,18 +230,18 @@ class KinChainInterface(object):
         for j in self._robot_description.joints:
             if j.type != 'fixed':
                 nf_joints += 1
-        print 'Base root=%s' % self._base_link
-        print 'Tip link=%s' % self._tip_link
-        print "URDF non-fixed joints: %d;" % nf_joints
-        print "URDF total joints: %d" % len(self.n_joints)
-        print "URDF links: %d" % len(self._robot_description.links)
-        print "KDL joints: %d" % self._kdl_tree.getNrOfJoints()
-        print "KDL segments: %d" % self._kdl_tree.getNrOfSegments()
+        print('Base root={}'.format(self._base_link))
+        print('Tip link={}'.format(self._tip_link))
+        print("URDF non-fixed joints: {:d};".format(nf_joints))
+        print("URDF total joints: {:d}".format(len(self.n_joints)))
+        print("URDF links: {:d}".format(len(self._robot_description.links)))
+        print("KDL joints: {:d}".format(self._kdl_tree.getNrOfJoints()))
+        print("KDL segments: {:d}".format(self._kdl_tree.getNrOfSegments()))
 
     def print_chain(self):
-        print 'Number of segments in chain=%d' % self._chain.getNrOfSegments()
+        print('Number of segments in chain={:d}'.format(self._chain.getNrOfSegments()))
         for idx in xrange(self._chain.getNrOfSegments()):
-            print '* ' + self._chain.getSegment(idx).getName()
+            print('* ' + self._chain.getSegment(idx).getName())
 
     def get_joint_angle(self, joint):
         assert joint in self._joint_angles, 'Invalid joint name'


### PR DESCRIPTION
Updates ancient Python print syntax so it works with Python3, and will therefore be ready to use with a focal/noetic build.

To test:
* Make sure your dave build is using this fork of `uuv_manipulators`.
* Build and run:
```
catkin_make
roslaunch uuv_dave uuv_dave.launch
```