### PR TITLE
[src]Fix future import which must be imported first

### DIFF
--- a/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py
+++ b/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import division
 import rospy
 
 import numpy as np
@@ -22,7 +23,6 @@ from uuv_manipulators_msgs.msg import EndeffectorState
 from std_msgs.msg import Float64
 from sensor_msgs.msg import JointState
 import time
-from __future__ import division
 
 class GripperInterface(object):
     TYPE = ['no_gripper', 'parallel', 'jaw']


### PR DESCRIPTION
With Python 3.8.10 (default install on Ubuntu 20.04) not having this patch will cause the following error

```bash
SyntaxError: from __future__ imports must occur at the beginning of the file
```