### PR TITLE
updates package xml for noetic

### DIFF
--- a/uuv_manipulators_control/package.xml
+++ b/uuv_manipulators_control/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>uuv_manipulators_control</name>
   <version>0.6.1</version>
   <description>Cartesian and gripper controllers.</description>
@@ -22,6 +22,7 @@
   <depend>sensor_msgs</depend>
   <depend>python-numpy</depend>
   <depend>tf</depend>
-  <depend>orocos_kdl</depend>
+  <depend condition="$ROS_DISTRO != noetic">orocos_kdl</depend>
+  <depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</depend>
 
 </package>

--- a/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py
+++ b/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import division
 
 import rospy
 
@@ -22,7 +23,6 @@ from uuv_manipulators_msgs.msg import EndeffectorState
 from std_msgs.msg import Float64
 from sensor_msgs.msg import JointState
 import time
-from __future__ import division
 
 class GripperInterface(object):
     TYPE = ['no_gripper', 'parallel', 'jaw']


### PR DESCRIPTION
This PR fixes a python import error we ran into when running in noetic where future imports need to be ahead of other imports. This also updates the package.xml for the uuv_manipulators_control package to be compatible with noetic.