### PR TITLE
Moving __future__ import to top of file

### DIFF
--- a/uuv_manipulators_control/scripts/joint_position_controller.py
+++ b/uuv_manipulators_control/scripts/joint_position_controller.py
@@ -132,7 +132,7 @@ class JointPositionController:
                         # Check for the joint limits
                         self._reference_pos[joint] = self._check_joint_limits(self._reference_pos[joint], joint)
                 self._last_joy_update = rospy.get_time()
-        except e:
+        except Exception as e:
             print('Error during joy parsing, message=', e)
 
 if __name__ == '__main__':

--- a/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py
+++ b/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# See PEP 238
+from __future__ import division
+
 import rospy
 
 import numpy as np
@@ -22,7 +25,7 @@ from uuv_manipulators_msgs.msg import EndeffectorState
 from std_msgs.msg import Float64
 from sensor_msgs.msg import JointState
 import time
-from __future__ import division
+
 
 class GripperInterface(object):
     TYPE = ['no_gripper', 'parallel', 'jaw']

--- a/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py
+++ b/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py
@@ -15,7 +15,6 @@
 
 # See PEP 238
 from __future__ import division
-
 import rospy
 
 import numpy as np
@@ -25,7 +24,10 @@ from uuv_manipulators_msgs.msg import EndeffectorState
 from std_msgs.msg import Float64
 from sensor_msgs.msg import JointState
 import time
+<<<<<<< Updated upstream
 
+=======
+>>>>>>> Stashed changes
 
 class GripperInterface(object):
     TYPE = ['no_gripper', 'parallel', 'jaw']

--- a/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py
+++ b/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py
@@ -24,10 +24,6 @@ from uuv_manipulators_msgs.msg import EndeffectorState
 from std_msgs.msg import Float64
 from sensor_msgs.msg import JointState
 import time
-<<<<<<< Updated upstream
-
-=======
->>>>>>> Stashed changes
 
 class GripperInterface(object):
     TYPE = ['no_gripper', 'parallel', 'jaw']


### PR DESCRIPTION
Should fix the bug discovered when running the example for Dave PR: https://github.com/Field-Robotics-Lab/dave/pull/149

If the __future__ import is not at the beginning of the file, a SyntaxError is raised:
```
$ ./gripper_controller.py 
Traceback (most recent call last):
  File "./gripper_controller.py", line 18, in <module>
    from uuv_manipulator_interfaces import GripperInterface
  File "/home/bsb/uuv_ws/devel/lib/python3/dist-packages/uuv_manipulator_interfaces/__init__.py", line 34, in <module>
    exec(__fh.read())
  File "<string>", line 17, in <module>
  File "/home/bsb/uuv_ws/src/uuv_manipulators/uuv_manipulators_kinematics/src/uuv_manipulator_interfaces/gripper.py", line 25
    from __future__ import division
    ^
SyntaxError: from __future__ imports must occur at the beginning of the file
```